### PR TITLE
Modularized code using a typescript file to import and refactoring code using engineering best practices

### DIFF
--- a/src/app/components/FrontendTypes.ts
+++ b/src/app/components/FrontendTypes.ts
@@ -1,3 +1,5 @@
+import { SeriesPoint } from '@visx/shape/lib/types';
+
 export interface PerfData {
   barStack: BarStackProp[],
   componentData?: Record<string, unknown>,
@@ -7,4 +9,51 @@ export interface PerfData {
 interface BarStackProp {
   snapshotId: string,
   route: URL,
+}
+
+// On-hover data for BarGraph/BarGraphComparison.tsx
+export interface TooltipData {
+  bar: SeriesPoint<snapshot>;
+  key: string;
+  index: number;
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+  color: string;
+}
+
+export interface snapshot {
+  snapshotId?: string;
+  children: [];
+  componentData: any;
+  name: string;
+  state: string;
+}
+
+export interface margin {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
+interface BarGraphBase {
+  width: number,
+  height: number,
+  data: PerfData,
+  comparison: string | [],
+}
+export interface BarGraphComparisonProps extends BarGraphBase {
+  setSeries: () => void,
+  series: unknown,
+  setAction: () => void,
+}
+
+export interface BarGraphProps extends BarGraphBase{
+  setRoute: () => void,
+  allRoutes: unknown,
+  filteredSnapshots: unknown,
+  snapshot: unknown,
+  setSnapshot: () => void
 }

--- a/src/app/components/FrontendTypes.ts
+++ b/src/app/components/FrontendTypes.ts
@@ -10,8 +10,8 @@ export interface Series {
   }
 
   interface ActionObj {
-    name: unknown,
-    seriesName: unknown,
+    name: string,
+    seriesName: string,
   }
 
 export interface PerfData {

--- a/src/app/components/FrontendTypes.ts
+++ b/src/app/components/FrontendTypes.ts
@@ -1,5 +1,19 @@
 import { SeriesPoint } from '@visx/shape/lib/types';
 
+// PerformanceVisx types
+
+export interface Series {
+    data: {
+      barStack: ActionObj[],
+    }
+    name: string
+  }
+
+  interface ActionObj {
+    name: unknown,
+    seriesName: unknown,
+  }
+
 export interface PerfData {
   barStack: BarStackProp[],
   componentData?: Record<string, unknown>,
@@ -9,6 +23,7 @@ export interface PerfData {
 interface BarStackProp {
   snapshotId: string,
   route: URL,
+  currentTab?: string,
 }
 
 // On-hover data for BarGraph/BarGraphComparison.tsx
@@ -42,11 +57,12 @@ interface BarGraphBase {
   width: number,
   height: number,
   data: PerfData,
-  comparison: string | [],
+  comparison: string | Series | [],
 }
+
 export interface BarGraphComparisonProps extends BarGraphBase {
   setSeries: () => void,
-  series: unknown,
+  series: number,
   setAction: () => void,
 }
 

--- a/src/app/components/FrontendTypes.ts
+++ b/src/app/components/FrontendTypes.ts
@@ -22,7 +22,7 @@ export interface PerfData {
 
 interface BarStackProp {
   snapshotId: string,
-  route: string | URL,
+  route: string,
   currentTab?: string,
 }
 

--- a/src/app/components/FrontendTypes.ts
+++ b/src/app/components/FrontendTypes.ts
@@ -1,0 +1,10 @@
+export interface PerfData {
+  barStack: BarStackProp[],
+  componentData?: Record<string, unknown>,
+  maxTotalRender: number,
+}
+
+interface BarStackProp {
+  snapshotId: string,
+  route: URL,
+}

--- a/src/app/components/FrontendTypes.ts
+++ b/src/app/components/FrontendTypes.ts
@@ -22,7 +22,7 @@ export interface PerfData {
 
 interface BarStackProp {
   snapshotId: string,
-  route: string,
+  route: string | URL,
   currentTab?: string,
 }
 

--- a/src/app/components/FrontendTypes.ts
+++ b/src/app/components/FrontendTypes.ts
@@ -22,7 +22,7 @@ export interface PerfData {
 
 interface BarStackProp {
   snapshotId: string,
-  route: URL | string,
+  route: string,
   currentTab?: string,
 }
 
@@ -41,7 +41,7 @@ export interface TooltipData {
 export interface snapshot {
   snapshotId?: string;
   children: [];
-  componentData: any;
+  componentData: { actualDuration: number } | undefined;
   name: string;
   state: string;
 }

--- a/src/app/components/FrontendTypes.ts
+++ b/src/app/components/FrontendTypes.ts
@@ -22,7 +22,7 @@ export interface PerfData {
 
 interface BarStackProp {
   snapshotId: string,
-  route: URL,
+  route: URL | string,
   currentTab?: string,
 }
 

--- a/src/app/components/StateRoute/PerformanceVisx/BarGraph.tsx
+++ b/src/app/components/StateRoute/PerformanceVisx/BarGraph.tsx
@@ -68,7 +68,7 @@ const tooltipStyles = {
   fontFamily: 'Roboto',
 };
 
-const BarGraph = (props: BarGraphProps): unknown => {
+const BarGraph = (props: BarGraphProps): JSX.Element => {
   const [{ tabs, currentTab }, dispatch] = useStoreContext();
   const {
     width,

--- a/src/app/components/StateRoute/PerformanceVisx/BarGraph.tsx
+++ b/src/app/components/StateRoute/PerformanceVisx/BarGraph.tsx
@@ -11,47 +11,7 @@ import { Text } from '@visx/text';
 import { schemeSet3 } from 'd3-scale-chromatic';
 import { onHover, onHoverExit, save } from '../../../actions/actions';
 import { useStoreContext } from '../../../store';
-import { PerfData } from '../../FrontendTypes';
-
-/* TYPESCRIPT */
-
-interface margin {
-  top: number;
-  right: number;
-  bottom: number;
-  left: number;
-}
-
-interface snapshot {
-  snapshotId?: string;
-  children: [];
-  componentData: any;
-  name: string;
-  state: string;
-}
-
-interface TooltipData {
-  bar: SeriesPoint<snapshot>;
-  key: string;
-  index: number;
-  height: number;
-  width: number;
-  x: number;
-  y: number;
-  color: string;
-}
-
-interface BarGraphProps {
-  width: number,
-  height: number,
-  data: PerfData,
-  comparison: unknown,
-  setRoute: () => void,
-  allRoutes: unknown,
-  filteredSnapshots: unknown,
-  snapshot: unknown,
-  setSnapshot: () => void
-}
+import { snapshot, TooltipData, margin, BarGraphProps } from '../../FrontendTypes';
 
 /* DEFAULTS */
 const margin = {

--- a/src/app/components/StateRoute/PerformanceVisx/BarGraph.tsx
+++ b/src/app/components/StateRoute/PerformanceVisx/BarGraph.tsx
@@ -11,6 +11,7 @@ import { Text } from '@visx/text';
 import { schemeSet3 } from 'd3-scale-chromatic';
 import { onHover, onHoverExit, save } from '../../../actions/actions';
 import { useStoreContext } from '../../../store';
+import { PerfData } from '../../FrontendTypes';
 
 /* TYPESCRIPT */
 
@@ -41,16 +42,16 @@ interface TooltipData {
 }
 
 interface BarGraphProps {
-    width: number,
-    height: number,
-    data: Record<string, unknown>,
-    comparison: unknown,
-    setRoute: () => void,
-    allRoutes: unknown,
-    filteredSnapshots: unknown,
-    snapshot: unknown,
-    setSnapshot: () => void
-  }
+  width: number,
+  height: number,
+  data: PerfData,
+  comparison: unknown,
+  setRoute: () => void,
+  allRoutes: unknown,
+  filteredSnapshots: unknown,
+  snapshot: unknown,
+  setSnapshot: () => void
+}
 
 /* DEFAULTS */
 const margin = {

--- a/src/app/components/StateRoute/PerformanceVisx/BarGraph.tsx
+++ b/src/app/components/StateRoute/PerformanceVisx/BarGraph.tsx
@@ -1,7 +1,6 @@
 // @ts-nocheck
 import React, { useEffect, useState } from 'react';
 import { BarStack } from '@visx/shape';
-import { SeriesPoint } from '@visx/shape/lib/types';
 import { Group } from '@visx/group';
 import { Grid } from '@visx/grid';
 import { AxisBottom, AxisLeft } from '@visx/axis';

--- a/src/app/components/StateRoute/PerformanceVisx/BarGraphComparison.tsx
+++ b/src/app/components/StateRoute/PerformanceVisx/BarGraphComparison.tsx
@@ -82,7 +82,7 @@ const BarGraphComparison = (props: BarGraphComparisonProps): JSX.Element => {
   // We'll then use it in the renderingScale function and compare
   // with the render time of the current tab.
   // The max render time will determine the Y-axis's highest number.
-  const calculateMaxTotalRender = (serie: string) => {
+  const calculateMaxTotalRender = (serie: string): number => {
     const currentSeriesBarStacks: number[] = !comparison[serie]
       ? []
       : comparison[serie].data.barStack;

--- a/src/app/components/StateRoute/PerformanceVisx/BarGraphComparison.tsx
+++ b/src/app/components/StateRoute/PerformanceVisx/BarGraphComparison.tsx
@@ -90,7 +90,7 @@ const BarGraphComparison = (props: BarGraphComparisonProps): JSX.Element => {
     if (currentSeriesBarStacks.length === 0) return 0;
     let currentMax = -Infinity;
     for (let i = 0; i < currentSeriesBarStacks.length; i += 1) {
-      const renderTimes = Object.values(currentSeriesBarStacks[i]).slice(1);
+      const renderTimes: number[] = Object.values(currentSeriesBarStacks[i]).slice(1);
       const renderTotal: number = renderTimes.reduce((acc, curr) => acc + curr);
       if (renderTotal > currentMax) currentMax = renderTotal;
     }

--- a/src/app/components/StateRoute/PerformanceVisx/BarGraphComparison.tsx
+++ b/src/app/components/StateRoute/PerformanceVisx/BarGraphComparison.tsx
@@ -15,6 +15,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import FormControl from '@material-ui/core/FormControl';
 import { onHover, onHoverExit, deleteSeries, setCurrentTabInApp } from '../../../actions/actions';
 import { useStoreContext } from '../../../store';
+import { PerfData } from '../../FrontendTypes';
 
 /* TYPESCRIPT */
 
@@ -48,7 +49,7 @@ interface TooltipData {
 interface BarGraphComparisonProps {
   width: number,
   height: number,
-  data: Record<string, unknown>,
+  data: PerfData,
   comparison: string | [],
   setSeries: () => void,
   series: unknown,

--- a/src/app/components/StateRoute/PerformanceVisx/BarGraphComparison.tsx
+++ b/src/app/components/StateRoute/PerformanceVisx/BarGraphComparison.tsx
@@ -1,7 +1,5 @@
-// @ts-nocheck
 import React, { useEffect } from 'react';
 import { BarStack } from '@visx/shape';
-import { SeriesPoint } from '@visx/shape/lib/types';
 import { Group } from '@visx/group';
 import { Grid } from '@visx/grid';
 import { AxisBottom, AxisLeft } from '@visx/axis';
@@ -15,46 +13,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import FormControl from '@material-ui/core/FormControl';
 import { onHover, onHoverExit, deleteSeries, setCurrentTabInApp } from '../../../actions/actions';
 import { useStoreContext } from '../../../store';
-import { PerfData } from '../../FrontendTypes';
-
-/* TYPESCRIPT */
-
-interface margin {
-  top: number;
-  right: number;
-  bottom: number;
-  left: number;
-}
-
-interface snapshot {
-  snapshotId?: string;
-  children: [];
-  componentData: any;
-  name: string;
-  state: string;
-}
-
-// On-hover data.
-interface TooltipData {
-  bar: SeriesPoint<snapshot>;
-  key: string;
-  index: number;
-  height: number;
-  width: number;
-  x: number;
-  y: number;
-  color: string;
-}
-
-interface BarGraphComparisonProps {
-  width: number,
-  height: number,
-  data: PerfData,
-  comparison: string | [],
-  setSeries: () => void,
-  series: unknown,
-  setAction: () => void,
-}
+import { snapshot, TooltipData, margin, BarGraphComparisonProps } from '../../FrontendTypes';
 
 /* DEFAULTS */
 const margin = {
@@ -118,10 +77,10 @@ const BarGraphComparison = (props: BarGraphComparisonProps): JSX.Element => {
   // We'll then use it in the renderingScale function and compare
   // with the render time of the current tab.
   // The max render time will determine the Y-axis's highest number.
-  const calculateMaxTotalRender = serie => {
-    const currentSeriesBarStacks = !comparison[serie]
+  const calculateMaxTotalRender = series => {
+    const currentSeriesBarStacks = !comparison[series]
       ? []
-      : comparison[serie].data.barStack;
+      : comparison[series].data.barStack;
     if (currentSeriesBarStacks.length === 0) return 0;
     let currentMax = -Infinity;
     for (let i = 0; i < currentSeriesBarStacks.length; i += 1) {

--- a/src/app/components/StateRoute/PerformanceVisx/BarGraphComparison.tsx
+++ b/src/app/components/StateRoute/PerformanceVisx/BarGraphComparison.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 import React, { useEffect } from 'react';
 import { BarStack } from '@visx/shape';
 import { Group } from '@visx/group';
@@ -77,10 +78,10 @@ const BarGraphComparison = (props: BarGraphComparisonProps): JSX.Element => {
   // We'll then use it in the renderingScale function and compare
   // with the render time of the current tab.
   // The max render time will determine the Y-axis's highest number.
-  const calculateMaxTotalRender = series => {
-    const currentSeriesBarStacks = !comparison[series]
+  const calculateMaxTotalRender = serie => {
+    const currentSeriesBarStacks = !comparison[serie]
       ? []
-      : comparison[series].data.barStack;
+      : comparison[serie].data.barStack;
     if (currentSeriesBarStacks.length === 0) return 0;
     let currentMax = -Infinity;
     for (let i = 0; i < currentSeriesBarStacks.length; i += 1) {

--- a/src/app/components/StateRoute/PerformanceVisx/BarGraphComparison.tsx
+++ b/src/app/components/StateRoute/PerformanceVisx/BarGraphComparison.tsx
@@ -71,7 +71,7 @@ const tooltipStyles = {
   fontFamily: 'Roboto',
 };
 
-const BarGraphComparison = (props: BarGraphComparisonProps): unknown => {
+const BarGraphComparison = (props: BarGraphComparisonProps): JSX.Element => {
   const [{ tabs, currentTab }, dispatch] = useStoreContext();
   const {
     width, height, data, comparison, setSeries, series, setAction,

--- a/src/app/components/StateRoute/PerformanceVisx/BarGraphComparison.tsx
+++ b/src/app/components/StateRoute/PerformanceVisx/BarGraphComparison.tsx
@@ -1,3 +1,4 @@
+// @ts-check
 /* eslint-disable no-param-reassign */
 import React, { useEffect } from 'react';
 import { BarStack } from '@visx/shape';

--- a/src/app/components/StateRoute/PerformanceVisx/BarGraphComparison.tsx
+++ b/src/app/components/StateRoute/PerformanceVisx/BarGraphComparison.tsx
@@ -82,7 +82,7 @@ const BarGraphComparison = (props: BarGraphComparisonProps): JSX.Element => {
   // We'll then use it in the renderingScale function and compare
   // with the render time of the current tab.
   // The max render time will determine the Y-axis's highest number.
-  const calculateMaxTotalRender = (serie: string): number => {
+  const calculateMaxTotalRender = (serie: number): number => {
     const currentSeriesBarStacks: number[] = !comparison[serie]
       ? []
       : comparison[serie].data.barStack;

--- a/src/app/components/StateRoute/PerformanceVisx/BarGraphComparison.tsx
+++ b/src/app/components/StateRoute/PerformanceVisx/BarGraphComparison.tsx
@@ -12,9 +12,13 @@ import { makeStyles } from '@material-ui/core/styles';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import FormControl from '@material-ui/core/FormControl';
-import { onHover, onHoverExit, deleteSeries, setCurrentTabInApp } from '../../../actions/actions';
+import {
+  onHover, onHoverExit, deleteSeries, setCurrentTabInApp,
+} from '../../../actions/actions';
 import { useStoreContext } from '../../../store';
-import { snapshot, TooltipData, margin, BarGraphComparisonProps } from '../../FrontendTypes';
+import {
+  snapshot, TooltipData, margin, BarGraphComparisonProps,
+} from '../../FrontendTypes';
 
 /* DEFAULTS */
 const margin = {
@@ -78,15 +82,15 @@ const BarGraphComparison = (props: BarGraphComparisonProps): JSX.Element => {
   // We'll then use it in the renderingScale function and compare
   // with the render time of the current tab.
   // The max render time will determine the Y-axis's highest number.
-  const calculateMaxTotalRender = serie => {
-    const currentSeriesBarStacks = !comparison[serie]
+  const calculateMaxTotalRender = (serie: string) => {
+    const currentSeriesBarStacks: number[] = !comparison[serie]
       ? []
       : comparison[serie].data.barStack;
     if (currentSeriesBarStacks.length === 0) return 0;
     let currentMax = -Infinity;
     for (let i = 0; i < currentSeriesBarStacks.length; i += 1) {
       const renderTimes = Object.values(currentSeriesBarStacks[i]).slice(1);
-      const renderTotal = renderTimes.reduce((acc, curr) => acc + curr);
+      const renderTotal: number = renderTimes.reduce((acc, curr) => acc + curr);
       if (renderTotal > currentMax) currentMax = renderTotal;
     }
     return currentMax;

--- a/src/app/components/StateRoute/PerformanceVisx/BarGraphComparison.tsx
+++ b/src/app/components/StateRoute/PerformanceVisx/BarGraphComparison.tsx
@@ -1,4 +1,4 @@
-// @ts-check
+// @ts-nocheck
 /* eslint-disable no-param-reassign */
 import React, { useEffect } from 'react';
 import { BarStack } from '@visx/shape';

--- a/src/app/components/StateRoute/PerformanceVisx/BarGraphComparisonActions.tsx
+++ b/src/app/components/StateRoute/PerformanceVisx/BarGraphComparisonActions.tsx
@@ -1,7 +1,6 @@
 // @ts-nocheck
 import React, { useEffect } from 'react';
 import { BarStack } from '@visx/shape';
-import { SeriesPoint } from '@visx/shape/lib/types';
 import { Group } from '@visx/group';
 import { Grid } from '@visx/grid';
 import { AxisBottom, AxisLeft } from '@visx/axis';

--- a/src/app/components/StateRoute/PerformanceVisx/BarGraphComparisonActions.tsx
+++ b/src/app/components/StateRoute/PerformanceVisx/BarGraphComparisonActions.tsx
@@ -15,35 +15,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import FormControl from '@material-ui/core/FormControl';
 import { deleteSeries, setCurrentTabInApp } from '../../../actions/actions';
 import { useStoreContext } from '../../../store';
-
-/* TYPESCRIPT */
-
-interface margin {
-  top: number;
-  right: number;
-  bottom: number;
-  left: number;
-}
-
-interface snapshot {
-  snapshotId?: string;
-  children: [];
-  componentData: any;
-  name: string;
-  state: string;
-}
-
-// On-hover data.
-interface TooltipData {
-  bar: SeriesPoint<snapshot>;
-  key: string;
-  index: number;
-  height: number;
-  width: number;
-  x: number;
-  y: number;
-  color: string;
-}
+import { TooltipData, margin } from '../../FrontendTypes';
 
 /* DEFAULTS */
 const margin = {
@@ -343,7 +315,7 @@ const BarGraphComparisonActions = props => {
           </div>
           <div>
             {
-            `${tooltipData.bar.data[tooltipData.key]} ms`
+              `${tooltipData.bar.data[tooltipData.key]} ms`
             }
           </div>
           <div>

--- a/src/app/components/StateRoute/PerformanceVisx/PerformanceVisx.tsx
+++ b/src/app/components/StateRoute/PerformanceVisx/PerformanceVisx.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-param-reassign */
 /* eslint-disable guard-for-in */
 /* eslint-disable no-restricted-syntax */
+/* eslint-disable max-len */
+
 import React, { useState, useEffect } from 'react';
 import {
   MemoryRouter as Router,
@@ -15,7 +17,7 @@ import BarGraphComparison from './BarGraphComparison';
 import BarGraphComparisonActions from './BarGraphComparisonActions';
 import { useStoreContext } from '../../../store';
 import { setCurrentTabInApp } from '../../../actions/actions';
-import { Bar } from '@visx/shape';
+import { PerfData } from '../../FrontendTypes';
 
 interface BarStackProps {
   width: number;
@@ -146,13 +148,13 @@ const getSnapshotIds = (obj, snapshotIds = []): string[] => {
   return snapshotIds;
 };
 
-type BarStackProp = Record <string, unknown>
+// type BarStackProp = Record <string, unknown | URL | number>
 
-interface PerfData {
-  barStack: BarStackProp[],
-  componentData?: Record<string, unknown>,
-  maxTotalRender: number,
-}
+// interface PerfData {
+//   barStack: BarStackProp[],
+//   componentData?: Record<string, unknown>,
+//   maxTotalRender: number,
+// }
 
 // Returns array of snapshot objs each with components and corresponding render times.
 const getPerfMetrics = (snapshots, snapshotsIds): PerfData => {
@@ -294,7 +296,6 @@ const PerformanceVisx = (props: BarStackProps): JSX.Element => {
       return (
         <div>
           <BarGraph
-            maxHeight={maxHeight}
             data={data}
             width={width}
             height={height}

--- a/src/app/components/StateRoute/PerformanceVisx/PerformanceVisx.tsx
+++ b/src/app/components/StateRoute/PerformanceVisx/PerformanceVisx.tsx
@@ -19,7 +19,7 @@ import { useStoreContext } from '../../../store';
 import { setCurrentTabInApp } from '../../../actions/actions';
 import { PerfData } from '../../FrontendTypes';
 
-interface BarStackProps {
+interface PerformanceVisxProps {
   width: number;
   height: number;
   snapshots: [];
@@ -171,8 +171,8 @@ const getPerfMetrics = (snapshots, snapshotsIds): PerfData => {
 };
 
 /* EXPORT COMPONENT */
-const PerformanceVisx = (props: BarStackProps): JSX.Element => {
-  // hook used to dispatch onhover action in rect
+const PerformanceVisx = (props: PerformanceVisxProps): JSX.Element => {
+  // hook used to dispatch onhover action in react
   const {
     width, height, snapshots, hierarchy,
   } = props;

--- a/src/app/components/StateRoute/PerformanceVisx/PerformanceVisx.tsx
+++ b/src/app/components/StateRoute/PerformanceVisx/PerformanceVisx.tsx
@@ -17,7 +17,7 @@ import BarGraphComparison from './BarGraphComparison';
 import BarGraphComparisonActions from './BarGraphComparisonActions';
 import { useStoreContext } from '../../../store';
 import { setCurrentTabInApp } from '../../../actions/actions';
-import { PerfData } from '../../FrontendTypes';
+import { PerfData, Series } from '../../FrontendTypes';
 
 interface PerformanceVisxProps {
   width: number;
@@ -148,14 +148,6 @@ const getSnapshotIds = (obj, snapshotIds = []): string[] => {
   return snapshotIds;
 };
 
-// type BarStackProp = Record <string, unknown | URL | number>
-
-// interface PerfData {
-//   barStack: BarStackProp[],
-//   componentData?: Record<string, unknown>,
-//   maxTotalRender: number,
-// }
-
 // Returns array of snapshot objs each with components and corresponding render times.
 const getPerfMetrics = (snapshots, snapshotsIds): PerfData => {
   const perfData: PerfData = {
@@ -188,18 +180,6 @@ const PerformanceVisx = (props: PerformanceVisxProps): JSX.Element => {
   useEffect(() => {
     dispatch(setCurrentTabInApp('performance'));
   }, [dispatch]);
-
-  type Series = {
-    data: {
-      barStack: ActionObj[],
-    }
-    name: string
-  }
-
-  type ActionObj = {
-    name: unknown,
-    seriesName: unknown,
-  }
 
   // Creates the actions array used to populate the compare actions dropdown
   const getActions = () => {


### PR DESCRIPTION
PerformanceVisx.tsx

- Added a type ‘currNum’ and assigned it a value of ‘number’ on line 87.
- Added typescript return value of ‘void’ for traverse on line 87.
- Declared a new const variable ‘childrenRenderTime’ and assigned it a value of currTotalRender + renderTime. 
- Passed in childrenRenderTime into line traverse on line 124.
- Updated typescript on line 150 from an empty object to ‘Record<string,unknown>’. 
- Updated typescript on line 164 to return a JSX.Element.
- Removed tabs and currentTab from line 169. 
- Removed return data on line 128
- Added type ActionObj, defined as an object with two key value pairs, name and seriesName
- Added a typescript type “SeriesArr” and assigned it a value of an object consisting a data key with an object with the key barStack, contains the value of an ActionObj inside an array
- Declared a constant to assign the value of localStorage.getItem(‘project’)
- Declare constant SeriesArr with typecheck Series[] and using ternary operator to determine the value by checking if project is null
- Added interface ComponentData. 
- Passed in interface PerfData to const perfData.
- Passed in PerfData as return value for const getPerfMetrics. 
- Moved declaration of ‘maxHeight’ outside of the conditional statement so it can be accessed globally. 
- Created a new file to store our FrontEnd typescript.
- Removed prop drilling of ‘maxHeight’ because it was not being used in child component. 
- Renamed our interface BarStackProps to ‘PerformanceVisxProps’ for syntax 

BarGraph.tsx

- Added return value of JSX.Element to line 71
- Passed in ‘PerfData’ to our data prop. 
- Passed in ‘PerfData’ to our data prop in BarGraphComparisson.tsx 
- Removed ‘TooltipData’, ‘BarGraphProps’ and ‘snapshot’ interface to be imported from FrontendTypes.ts

BarGraphComparison.tsx

- Removed import of ‘SeriesPoint’. 
- Removed ‘TooltipData’, ‘BarGraphComparisonProps’ and ‘snapshot’ interface to be imported from FrontendTypes.ts.

FrontEndTypes.ts

- Moved interface TooltipData and snapshot from BarGraphComparison. 
- Imported ‘SeriesPoint’ from @vix/shape/lib/types
- Created an interface ‘PerfData’.
- Created an interface ‘BarStackProp’.
- Created an interface ‘BarGraphBase’.
- Moved interface ‘BarGraphComparisonProps’ from BarGraphComparison.tsx.
- Moved interface ‘BarGraphProps’ from BarGraph.tsx.
- Moved type ‘Series’ from Performancevisx.tsx.
- Moved type ‘ActionObj’ from Performancevisx.tsx 